### PR TITLE
Implement document CRUD operations

### DIFF
--- a/src/main/java/bts/sio/azurimmo/controller/DocumentController.java
+++ b/src/main/java/bts/sio/azurimmo/controller/DocumentController.java
@@ -1,0 +1,60 @@
+package bts.sio.azurimmo.controller;
+
+import bts.sio.azurimmo.model.Document;
+import bts.sio.azurimmo.service.DocumentService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/documents")
+@CrossOrigin(origins = {"http://localhost:3000", "http://127.0.0.1:3000"}, methods = {
+        RequestMethod.GET,
+        RequestMethod.POST,
+        RequestMethod.PUT,
+        RequestMethod.DELETE,
+        RequestMethod.OPTIONS,
+        RequestMethod.PATCH
+})
+public class DocumentController {
+
+    @Autowired
+    private DocumentService documentService;
+
+    @GetMapping("/")
+    public List<Document> getAllDocuments() {
+        return documentService.getAllDocuments();
+    }
+
+    @GetMapping("/{id}")
+    public Document getDocumentById(@PathVariable Long id) {
+        return documentService.getDocumentById(id);
+    }
+
+    @PostMapping("/")
+    public Document createDocument(@RequestBody Document document) {
+        return documentService.saveDocument(document);
+    }
+
+    @PutMapping("/{id}")
+    public Document updateDocument(@PathVariable Long id, @RequestBody Document document) {
+        document.setId(id);
+        return documentService.saveDocument(document);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> deleteDocument(@PathVariable Long id) {
+        boolean deleted = documentService.deleteDocument(id);
+        if (deleted) {
+            return ResponseEntity.ok().build();
+        }
+        return ResponseEntity.status(404).body("Document introuvable.");
+    }
+
+    @GetMapping("/contrat/{contratId}")
+    public List<Document> getDocumentsByContrat(@PathVariable Long contratId) {
+        return documentService.getDocumentsByContratId(contratId);
+    }
+}

--- a/src/main/java/bts/sio/azurimmo/service/DocumentService.java
+++ b/src/main/java/bts/sio/azurimmo/service/DocumentService.java
@@ -4,14 +4,6 @@ import bts.sio.azurimmo.model.Document;
 import bts.sio.azurimmo.repository.DocumentRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
-
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
@@ -20,6 +12,34 @@ public class DocumentService {
 
     @Autowired
     private DocumentRepository documentRepository;
+
+    // Récupérer tous les documents
+    public List<Document> getAllDocuments() {
+        return documentRepository.findAll();
+    }
+
+    // Récupérer un document par son ID
+    public Document getDocumentById(Long id) {
+        Optional<Document> document = documentRepository.findById(id);
+        return document.orElse(null);
+    }
+
+    // Ajouter ou modifier un document
+    public Document saveDocument(Document document) {
+        if (document.getId() != null && document.getId() == 0) {
+            document.setId(null);
+        }
+        return documentRepository.save(document);
+    }
+
+    // Supprimer un document
+    public boolean deleteDocument(Long id) {
+        if (documentRepository.existsById(id)) {
+            documentRepository.deleteById(id);
+            return true;
+        }
+        return false;
+    }
 
     // Récupérer tous les documents d'un contrat
     public List<Document> getDocumentsByContratId(Long contratId) {


### PR DESCRIPTION
## Summary
- add `DocumentController` REST endpoints
- implement full CRUD logic in `DocumentService`

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842a9809154832e8e6decbe6e26b939